### PR TITLE
Normative: Make index properties for immutable-backed TypedArrays non-configurable and non-writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Should trying to write data in an immutable ArrayBuffer via a TypedArray element
 </dt>
 <dt>
 
+Should the index properties of a TypedArray backed by an immutable ArrayBuffer be configurable and writable?
+
+</dt>
+<dd>
+
+No, TypedArray index properties should continue to track the state of the underlying buffer without individual bookkeeping.
+
+</dd>
+<dt>
+
 Should TypedArray write methods (`copyWithin`, `fill`, `reverse`, `set`, etc.) throw when their backing ArrayBuffer is immutable but the targeted range is zero-length? If so, how early or late in the algorithm? The methods currently inspect arguments after ValidateTypedArray.
 
 </dt>

--- a/spec.emu
+++ b/spec.emu
@@ -20,6 +20,83 @@ contributors: Mark S. Miller, Richard Gibson
     <emu-clause id="sec-typedarray-exotic-objects" oldids="sec-integer-indexed-exotic-objects" number="5">
       <h1>TypedArray Exotic Objects</h1>
 
+      <emu-clause id="sec-typedarray-getownproperty" oldids="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method" number="1">
+        <h1>
+          [[GetOwnProperty]] (
+            _P_: a property key,
+          ): a normal completion containing either a Property Descriptor or *undefined*
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a TypedArray _O_</dd>
+        </dl>
+        <emu-alg>
+          1. If _P_ is a String, then
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
+            1. If _numericIndex_ is not *undefined*, then
+              1. Let _value_ be TypedArrayGetElement(_O_, _numericIndex_).
+              1. If _value_ is *undefined*, return *undefined*.
+              1. <ins>Let _mutable_ be *true*.</ins>
+              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, set _mutable_ to *false*.</ins>
+              1. Return the PropertyDescriptor { [[Value]]: _value_, [[Writable]]: <del>*true*</del> <ins>_mutable_</ins>, [[Enumerable]]: *true*, [[Configurable]]: <del>*true*</del> <ins>_mutable_</ins> }.
+          1. Return OrdinaryGetOwnProperty(_O_, _P_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-typedarray-defineownproperty" oldids="sec-integer-indexed-exotic-objects-defineownproperty-p-desc" type="internal method" number="3">
+        <h1>
+          [[DefineOwnProperty]] (
+            _P_: a property key,
+            _Desc_: a Property Descriptor,
+          ): either a normal completion containing a Boolean or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a TypedArray _O_</dd>
+        </dl>
+        <emu-alg>
+          1. If _P_ is a String, then
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
+            1. If _numericIndex_ is not *undefined*, then
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
+              1. <ins>Let _mutable_ be *true*.</ins>
+              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, set _mutable_ to *false*.</ins>
+              1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is <del>*false*</del> <ins>not _mutable_</ins>, return *false*.
+              1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
+              1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+              1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is <del>*false*</del> <ins>not _mutable_</ins>, return *false*.
+              1. <ins>If _Desc_ has a [[Value]] field and _mutable_ is *false* and SameValue(_Desc_.[[Value]], TypedArrayGetElement(_O_, _numericIndex_)) is *false*, return *false*.</ins>
+              1. If _Desc_ has a [[Value]] field <ins>and _mutable_ is *true*</ins>, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).
+              1. Return *true*.
+          1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-typedarray-set" oldids="sec-integer-indexed-exotic-objects-set-p-v-receiver" type="internal method" number="5">
+        <h1>
+          [[Set]] (
+            _P_: a property key,
+            _V_: an ECMAScript language value,
+            _Receiver_: an ECMAScript language value,
+          ): either a normal completion containing a Boolean or a throw completion
+        </h1>
+        <dl class="header">
+          <dt>for</dt>
+          <dd>a TypedArray _O_</dd>
+        </dl>
+        <emu-alg>
+          1. If _P_ is a String, then
+            1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
+            1. If _numericIndex_ is not *undefined*, then
+              1. If SameValue(_O_, _Receiver_) is *true*, then
+                1. <ins>IsValidIntegerIndex(_O_, _numericIndex_) is *true* and IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, return *false*.</ins>
+                1. Perform ? TypedArraySetElement(_O_, _numericIndex_, _V_).
+                1. Return *true*.
+              1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *true*.
+          1. Return ? OrdinarySet(_O_, _P_, _V_, _Receiver_).
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-typedarraysetelement" oldids="sec-integerindexedelementset" type="abstract operation" number="16">
         <h1>
           TypedArraySetElement (


### PR DESCRIPTION
...allowing such TypedArrays to be frozen.

<details><summary>GFM rendering of this PR's diff from upstream ECMA-262: <del>removals</del>, <ins>additions</ins></summary>

<h1><span class="secnum">10.4.5</span> TypedArray Exotic Objects</h1>

<emu-clause id="sec-typedarray-getownproperty" oldids="sec-integer-indexed-exotic-objects-getownproperty-p" type="internal method" number="1"><span id="sec-integer-indexed-exotic-objects-getownproperty-p"></span>
  <h1><span class="secnum">10.4.5.1</span> <var class="field">[[GetOwnProperty]]</var> ( <var>P</var> )</h1>
  <p>The <var class="field">[[GetOwnProperty]]</var> internal method of a <emu-xref href="#typedarray"><a href="https://tc39.es/ecma262/#typedarray">TypedArray</a></emu-xref> <var>O</var> takes argument <var>P</var> (a <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">property key</a></emu-xref>) and returns a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> either a <emu-xref href="#sec-property-descriptor-specification-type"><a href="https://tc39.es/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a></emu-xref> or <emu-val>undefined</emu-val>. It performs the following steps when called:</p>
  <emu-alg><ol><li>If <var>P</var> <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">is a String</a></emu-xref>, then<ol><li>Let <var>numericIndex</var> be <emu-xref aoid="CanonicalNumericIndexString"><a href="https://tc39.es/ecma262/#sec-canonicalnumericindexstring">CanonicalNumericIndexString</a></emu-xref>(<var>P</var>).</li><li>If <var>numericIndex</var> is not <emu-val>undefined</emu-val>, then<ol><li>Let <var>value</var> be <emu-xref aoid="TypedArrayGetElement"><a href="https://tc39.es/ecma262/#sec-typedarraygetelement">TypedArrayGetElement</a></emu-xref>(<var>O</var>, <var>numericIndex</var>).</li><li>If <var>value</var> is <emu-val>undefined</emu-val>, return <emu-val>undefined</emu-val>.</li><li><ins>Let <var>mutable</var> be <emu-val>true</emu-val>.</ins></li><li><ins>If <emu-xref aoid="IsImmutableBuffer" id="_ref_0"><a href="https://papers.agoric.com/tc39-proposal-immutable-arraybuffer/#sec-isimmutablebuffer">IsImmutableBuffer</a></emu-xref>(<var>O</var>.<var class="field">[[ViewedArrayBuffer]]</var>) is <emu-val>true</emu-val>, set <var>mutable</var> to <emu-val>false</emu-val>.</ins></li><li>Return the PropertyDescriptor { <var class="field">[[Value]]</var>: <var>value</var>, <var class="field">[[Writable]]</var>: <del><emu-val>true</emu-val></del> <ins><var>mutable</var></ins>, <var class="field">[[Enumerable]]</var>: <emu-val>true</emu-val>, <var class="field">[[Configurable]]</var>: <del><emu-val>true</emu-val></del> <ins><var>mutable</var></ins>&nbsp;}.</li></ol></li></ol></li><li>Return <emu-xref aoid="OrdinaryGetOwnProperty"><a href="https://tc39.es/ecma262/#sec-ordinarygetownproperty">OrdinaryGetOwnProperty</a></emu-xref>(<var>O</var>, <var>P</var>).</li></ol></emu-alg>
</emu-clause>

<emu-clause id="sec-typedarray-defineownproperty" oldids="sec-integer-indexed-exotic-objects-defineownproperty-p-desc" type="internal method" number="3"><span id="sec-integer-indexed-exotic-objects-defineownproperty-p-desc"></span>
  <h1><span class="secnum">10.4.5.3</span> <var class="field">[[DefineOwnProperty]]</var> ( <var>P</var>, <var>Desc</var> )</h1>
  <p>The <var class="field">[[DefineOwnProperty]]</var> internal method of a <emu-xref href="#typedarray"><a href="https://tc39.es/ecma262/#typedarray">TypedArray</a></emu-xref> <var>O</var> takes arguments <var>P</var> (a <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">property key</a></emu-xref>) and <var>Desc</var> (a <emu-xref href="#sec-property-descriptor-specification-type"><a href="https://tc39.es/ecma262/#sec-property-descriptor-specification-type">Property Descriptor</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a Boolean or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
  <emu-alg><ol><li>If <var>P</var> <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">is a String</a></emu-xref>, then<ol><li>Let <var>numericIndex</var> be <emu-xref aoid="CanonicalNumericIndexString"><a href="https://tc39.es/ecma262/#sec-canonicalnumericindexstring">CanonicalNumericIndexString</a></emu-xref>(<var>P</var>).</li><li>If <var>numericIndex</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <emu-xref aoid="IsValidIntegerIndex"><a href="https://tc39.es/ecma262/#sec-isvalidintegerindex">IsValidIntegerIndex</a></emu-xref>(<var>O</var>, <var>numericIndex</var>) is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li><ins>Let <var>mutable</var> be <emu-val>true</emu-val>.</ins></li><li><ins>If <emu-xref aoid="IsImmutableBuffer" id="_ref_1"><a href="https://papers.agoric.com/tc39-proposal-immutable-arraybuffer/#sec-isimmutablebuffer">IsImmutableBuffer</a></emu-xref>(<var>O</var>.<var class="field">[[ViewedArrayBuffer]]</var>) is <emu-val>true</emu-val>, set <var>mutable</var> to <emu-val>false</emu-val>.</ins></li><li>If <var>Desc</var> has a <var class="field">[[Configurable]]</var> field and <var>Desc</var>.<var class="field">[[Configurable]]</var> is <del><emu-val>false</emu-val></del> <ins>not <var>mutable</var></ins>, return <emu-val>false</emu-val>.</li><li>If <var>Desc</var> has an <var class="field">[[Enumerable]]</var> field and <var>Desc</var>.<var class="field">[[Enumerable]]</var> is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</li><li>If <emu-xref aoid="IsAccessorDescriptor"><a href="https://tc39.es/ecma262/#sec-isaccessordescriptor">IsAccessorDescriptor</a></emu-xref>(<var>Desc</var>) is <emu-val>true</emu-val>, return <emu-val>false</emu-val>.</li><li>If <var>Desc</var> has a <var class="field">[[Writable]]</var> field and <var>Desc</var>.<var class="field">[[Writable]]</var> is <del><emu-val>false</emu-val></del> <ins>not <var>mutable</var></ins>, return <emu-val>false</emu-val>.</li><li><ins>If <var>Desc</var> has a <var class="field">[[Value]]</var> field and <var>mutable</var> is <emu-val>false</emu-val> and <emu-xref aoid="SameValue"><a href="https://tc39.es/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>Desc</var>.<var class="field">[[Value]]</var>, <emu-xref aoid="TypedArrayGetElement"><a href="https://tc39.es/ecma262/#sec-typedarraygetelement">TypedArrayGetElement</a></emu-xref>(<var>O</var>, <var>numericIndex</var>)) is <emu-val>false</emu-val>, return <emu-val>false</emu-val>.</ins></li><li>If <var>Desc</var> has a <var class="field">[[Value]]</var> field <ins>and <var>mutable</var> is <emu-val>true</emu-val></ins>, perform ?&nbsp;<emu-xref aoid="TypedArraySetElement" id="_ref_2"><a href="https://papers.agoric.com/tc39-proposal-immutable-arraybuffer/#sec-typedarraysetelement">TypedArraySetElement</a></emu-xref>(<var>O</var>, <var>numericIndex</var>, <var>Desc</var>.<var class="field">[[Value]]</var>).</li><li>Return <emu-val>true</emu-val>.</li></ol></li></ol></li><li>Return !&nbsp;<emu-xref aoid="OrdinaryDefineOwnProperty"><a href="https://tc39.es/ecma262/#sec-ordinarydefineownproperty">OrdinaryDefineOwnProperty</a></emu-xref>(<var>O</var>, <var>P</var>, <var>Desc</var>).</li></ol></emu-alg>
</emu-clause>

<emu-clause id="sec-typedarray-set" oldids="sec-integer-indexed-exotic-objects-set-p-v-receiver" type="internal method" number="5"><span id="sec-integer-indexed-exotic-objects-set-p-v-receiver"></span>
  <h1><span class="secnum">10.4.5.5</span> <var class="field">[[Set]]</var> ( <var>P</var>, <var>V</var>, <var>Receiver</var> )</h1>
  <p>The <var class="field">[[Set]]</var> internal method of a <emu-xref href="#typedarray"><a href="https://tc39.es/ecma262/#typedarray">TypedArray</a></emu-xref> <var>O</var> takes arguments <var>P</var> (a <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">property key</a></emu-xref>), <var>V</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>), and <var>Receiver</var> (an <emu-xref href="#sec-ecmascript-language-types"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types">ECMAScript language value</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a Boolean or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
  <emu-alg><ol><li>If <var>P</var> <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">is a String</a></emu-xref>, then<ol><li>Let <var>numericIndex</var> be <emu-xref aoid="CanonicalNumericIndexString"><a href="https://tc39.es/ecma262/#sec-canonicalnumericindexstring">CanonicalNumericIndexString</a></emu-xref>(<var>P</var>).</li><li>If <var>numericIndex</var> is not <emu-val>undefined</emu-val>, then<ol><li>If <emu-xref aoid="SameValue"><a href="https://tc39.es/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>O</var>, <var>Receiver</var>) is <emu-val>true</emu-val>, then<ol><li><ins><emu-xref aoid="IsValidIntegerIndex"><a href="https://tc39.es/ecma262/#sec-isvalidintegerindex">IsValidIntegerIndex</a></emu-xref>(<var>O</var>, <var>numericIndex</var>) is <emu-val>true</emu-val> and <emu-xref aoid="IsImmutableBuffer" id="_ref_3"><a href="https://papers.agoric.com/tc39-proposal-immutable-arraybuffer/#sec-isimmutablebuffer">IsImmutableBuffer</a></emu-xref>(<var>O</var>.<var class="field">[[ViewedArrayBuffer]]</var>) is <emu-val>true</emu-val>, return <emu-val>false</emu-val>.</ins></li><li>Perform ?&nbsp;<emu-xref aoid="TypedArraySetElement" id="_ref_4"><a href="https://papers.agoric.com/tc39-proposal-immutable-arraybuffer/#sec-typedarraysetelement">TypedArraySetElement</a></emu-xref>(<var>O</var>, <var>numericIndex</var>, <var>V</var>).</li><li>Return <emu-val>true</emu-val>.</li></ol></li><li>If <emu-xref aoid="IsValidIntegerIndex"><a href="https://tc39.es/ecma262/#sec-isvalidintegerindex">IsValidIntegerIndex</a></emu-xref>(<var>O</var>, <var>numericIndex</var>) is <emu-val>false</emu-val>, return <emu-val>true</emu-val>.</li></ol></li></ol></li><li>Return ?&nbsp;<emu-xref aoid="OrdinarySet"><a href="https://tc39.es/ecma262/#sec-ordinaryset">OrdinarySet</a></emu-xref>(<var>O</var>, <var>P</var>, <var>V</var>, <var>Receiver</var>).</li></ol></emu-alg></emu-clause>

</details>